### PR TITLE
Add more sites

### DIFF
--- a/_includes/20detikPlayer.html
+++ b/_includes/20detikPlayer.html
@@ -1,0 +1,12 @@
+<!-- Feel free to change the width and height to your desired video size. -->
+
+<div class="embed-container">
+  <iframe
+      src="https://20.detik.com/embed/{{ include.id }}"
+      width="700"
+      height="480"
+      frameborder="0"
+      scrolling="no"
+      allowfullscreen="true">
+  </iframe>
+</div>

--- a/_includes/dailymotionPlayer.html
+++ b/_includes/dailymotionPlayer.html
@@ -1,0 +1,12 @@
+<!-- Feel free to change the width and height to your desired video size. -->
+
+<div class="embed-container">
+  <iframe
+      src="https://www.dailymotion.com/embed/video/{{ include.id }}"
+      width="700"
+      height="480"
+      frameborder="0"
+      allowfullscreen=""
+      allow="autoplay">
+  </iframe>
+</div>

--- a/_includes/linetodayPlayer.html
+++ b/_includes/linetodayPlayer.html
@@ -1,0 +1,13 @@
+<!-- Feel free to change the width and height to your desired video size. -->
+<!-- Remember to include 2-letter country name, too! (LINE TODAY is available on different regions) -->
+
+<div class="embed-container">
+  <iframe
+      src="https://today.line.me/{{ include.country }}/embed/{{ include.id }}"
+      width="700"
+      height="480"
+      frameborder="0"
+      allowfullscreen=""
+      allow="autoplay; encrypted-media">
+  </iframe>
+</div>

--- a/_includes/metubePlayer.html
+++ b/_includes/metubePlayer.html
@@ -1,0 +1,11 @@
+<!-- Feel free to change the width and height to your desired video size. -->
+
+<div class="embed-container">
+  <iframe
+      src="https://www.metube.id/embed/{{ include.id }}"
+      width="700"
+      height="480"
+      frameborder="0"
+      allowfullscreen="">
+  </iframe>
+</div>

--- a/_includes/vidioPlayer.html
+++ b/_includes/vidioPlayer.html
@@ -1,0 +1,14 @@
+<!-- Feel free to change the width and height to your desired video size. -->
+
+<div class="embed-container">
+  <iframe
+      class="vidio-embed"
+      src="https://www.vidio.com/embed/{{ include.id }}"
+      width="700"
+      height="480"
+      scrolling="no"
+      frameborder="0"
+      allowfullscreen="">
+  </iframe>
+  <script src="//cdn0-a.production.vidio.static6.com/assets/javascripts/vidio-embed.js"></script>
+</div>


### PR DESCRIPTION
I have modified this project to include more video hosting and news sites (mostly Indonesian):

+ 20 Detik (https://20.detik.com)
+ Dailymotion (https://www.dailymotion.com)
+ LINE TODAY (https://today.line.me)
+ Metube (https://www.metube.id)
+ Vidio (https://www.vidio.com)

Here, different LINE TODAY contents are served in different countries, hence I have also added a new, `country` parameter (to be filled with 2-letter country code) for the template.

To ensure consistency, I decided to use the same size configuration as of YouTube, with few modifications based on the default `iframe` tag templates provided by respective sites.